### PR TITLE
CLI-16: Add support for class field edition

### DIFF
--- a/src/main/java/org/xwiki/contrib/cli/Command.java
+++ b/src/main/java/org/xwiki/contrib/cli/Command.java
@@ -395,7 +395,7 @@ public record Command(
             + "\nMount Path:      " + mountPath
             + "\nSync Path:       " + syncPath
             + "\nSync data source:" + syncDataSource
-            + "\nUsed Doc URL:  " + getDocURL()
+            + "\nUsed Doc URL:  " + getDocURL(false, false, false)
             + "\nDebug:         " + debug
             + "\n + printXML:   " + printXML);
     }
@@ -431,10 +431,10 @@ public record Command(
         return pos != -1 && value.indexOf('\n', pos) != -1;
     }
 
-    private String getDocURL()
+    private String getDocURL(boolean withObjects, boolean withAttachments, boolean withClass)
     {
         try {
-            return Utils.getDocRestURLFromCommand(this, wiki, page, false);
+            return Utils.getDocRestURLFromCommand(this, wiki, page, withObjects, withAttachments, withClass);
         } catch (DocException e) {
             return "(N/A)";
         }

--- a/src/main/java/org/xwiki/contrib/cli/Utils.java
+++ b/src/main/java/org/xwiki/contrib/cli/Utils.java
@@ -110,9 +110,8 @@ public final class Utils
     }
 
     /**
-     * Convert a page reference to a path in the XFF format. Note we use this format for the
-     * synced dir path. For REST API we need some escape char, so you need to use fromReferenceToRestPath method
-     * instead.
+     * Convert a page reference to a path in the XFF format. Note we use this format for the synced dir path. For REST
+     * API we need some escape char, so you need to use fromReferenceToRestPath method instead.
      *
      * @param reference the page, in dotted notation.
      * @return the page path in the XFF format. Example: Main.WebHome -> /spaces/Main/pages/WebHome.
@@ -124,9 +123,8 @@ public final class Utils
     }
 
     /**
-     * Convert a page reference to a path in the XFF format. Note we use this format for the
-     * synced dir path. For REST API we need some escape char, so you need to use fromReferenceToRestPath method
-     * instead.
+     * Convert a page reference to a path in the XFF format. Note we use this format for the synced dir path. For REST
+     * API we need some escape char, so you need to use fromReferenceToRestPath method instead.
      *
      * @param reference a page reference.
      * @return the page path in the XFF format. Example: Main.WebHome -> /spaces/Main/pages/WebHome.
@@ -375,7 +373,8 @@ public final class Utils
      * @param withObjects define if we need to get the document with objects.
      * @return the REST document URL specified by the given user-provided command.
      */
-    public static String getDocRestURLFromCommand(Command cmd, String wikiParam, String page, boolean withObjects)
+    public static String getDocRestURLFromCommand(Command cmd, String wikiParam, String page, boolean withObjects,
+        boolean withAttchments, boolean withClass)
         throws DocException
     {
         var wiki = (wikiParam == null || wikiParam.isEmpty()) ? XWIKI : wikiParam;
@@ -383,10 +382,19 @@ public final class Utils
             throw new MessageForUserDocException(EXCEPTION_MSG_SPECIFY_PAGE);
         }
 
-        return cmd.url()
-            + REST_URL_PREFIX + wiki
-            + fromReferenceToRestPath(page)
-            + (withObjects ? "?objects=true&attachments=true" : "");
+        var url = new StringBuilder(cmd.url());
+        url.append(REST_URL_PREFIX).append(wiki);
+        url.append(Utils.fromReferenceToRestPath(page));
+        if (withObjects || withAttchments || withClass) {
+            var params = new String[] {
+                withObjects ? "objects=true" : "",
+                withAttchments ? "attachments=true" : "",
+                withClass ? "class=true" : "",
+            };
+            url.append("?");
+            url.append(String.join("&", params));
+        }
+        return url.toString();
     }
 
     /**

--- a/src/main/java/org/xwiki/contrib/cli/document/AbstractXMLDoc.java
+++ b/src/main/java/org/xwiki/contrib/cli/document/AbstractXMLDoc.java
@@ -21,10 +21,13 @@
 package org.xwiki.contrib.cli.document;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.dom4j.Document;
 import org.dom4j.Element;
@@ -33,6 +36,7 @@ import org.xwiki.contrib.cli.Command;
 import org.xwiki.contrib.cli.DocException;
 import org.xwiki.contrib.cli.Utils;
 import org.xwiki.contrib.cli.document.element.AttachmentInfo;
+import org.xwiki.contrib.cli.document.element.ClassProperty;
 import org.xwiki.contrib.cli.document.element.ObjectInfo;
 import org.xwiki.contrib.cli.document.element.Property;
 
@@ -41,6 +45,8 @@ import static java.lang.System.err;
 abstract class AbstractXMLDoc
 {
     protected static final String NODE_NAME_CLASS_NAME = "className";
+
+    protected static final String NODE_NAME_CLASS = "class";
 
     protected static final String NODE_NAME_NUMBER = "number";
 
@@ -62,6 +68,23 @@ abstract class AbstractXMLDoc
 
     protected static final String LINE = "\n-----\n";
 
+    protected static final String XPATH_XML_CLASS_PROPERTIES = "class/*[not("
+        + "name()='name' or "
+        + "name()='customClass' or "
+        + "name()='customMapping' or "
+        + "name()='defaultViewSheet' or "
+        + "name()='defaultEditSheet' or "
+        + "name()='defaultWeb' or "
+        + "name()='nameField' or "
+        + "name()='validationScript')]";
+
+    protected static final String XPATH_XML_CLASS_PROPERTY_FIELD = XPATH_XML_CLASS_PROPERTIES + "/%s/%s";
+
+    protected static final String XPATH_REST_CLASS_PROPERTIES = "class/property";
+
+    protected static final String XPATH_REST_CLASS_PROPERTY_FIELD = XPATH_REST_CLASS_PROPERTIES +
+        "[@name = '%s']/attribute[@name = '%s'";
+
     protected static final String XPATH_REST_OBJECT = "xwiki:objects/xwiki:objectSummary";
 
     protected static final String XPATH_REST_ATTACHMENT = "xwiki:attachments/xwiki:attachment";
@@ -69,6 +92,11 @@ abstract class AbstractXMLDoc
     protected static final String XPATH_REST_PROPERTY_NAME = "xwiki:property[@name = '%s']/xwiki:value";
 
     protected static final String XPATH_XML_PROPERTY = "property/%s";
+
+    protected static final String XPATH_ATTRIBUTE_NAME = "attribute[@name = '%s']";
+
+    protected static final String[] CLASS_PROPERTY_FIELDS = new String[] { "prettyName", "hint", "customDisplay",
+        "validationRegExp", "validationMessage" };
 
     protected final Command cmd;
 
@@ -258,6 +286,61 @@ abstract class AbstractXMLDoc
         return getDom().valueOf("//xwikidoc/@reference");
     }
 
+    public Collection<ClassProperty> getClassInfo() throws DocException
+    {
+        var domdoc = getDom();
+        var root = (Element) domdoc.getRootElement();
+        var propertyNodes = root.selectNodes(fromRest ? XPATH_REST_CLASS_PROPERTIES : XPATH_XML_CLASS_PROPERTIES);
+        if (propertyNodes == null) {
+            return Collections.emptyList();
+        }
+        var properties = new ArrayList<ClassProperty>(propertyNodes.size());
+        for (var p : propertyNodes) {
+            if (fromRest) {
+                var element = (Element) p;
+                var classProperty = new ClassProperty(element.attributeValue(NODE_NAME),
+                    Arrays.stream(CLASS_PROPERTY_FIELDS)
+                        .collect(Collectors.toMap(i -> i,
+                            i -> ((Element) element.selectSingleNode(String.format(XPATH_ATTRIBUTE_NAME, i)))
+                                .attributeValue("value"))));
+                properties.add(classProperty);
+            } else {
+                var classProperty = new ClassProperty(p.getName(),
+
+                    Arrays.stream(CLASS_PROPERTY_FIELDS)
+                        .collect(Collectors.toMap(i -> i,
+                            i -> getElement((Element) p, i).getText())));
+                properties.add(classProperty);
+            }
+        }
+        return properties;
+    }
+
+    public Optional<String> getClassPropertyField(String property, String field) throws DocException
+    {
+        var propertyElement = getClassPropertyFieldElement(property, field);
+        return propertyElement.map(i -> {
+            if (fromRest) {
+                return ((Element) i).attributeValue("value");
+            } else {
+                return i.getText();
+            }
+        });
+    }
+
+    public void setClassPropertyField(String property, String field, String value) throws DocException
+    {
+        var propertyElement = getClassPropertyFieldElement(property, field);
+        if (propertyElement.isEmpty()) {
+            throw new DocException("Couln't find this property");
+        }
+        if (fromRest) {
+            propertyElement.get().setText(value);
+        } else {
+            ((Element) propertyElement.get()).addAttribute("value", value);
+        }
+    }
+
     protected void setXML(String str, boolean fromRest)
     {
         this.fromRest = fromRest;
@@ -422,6 +505,21 @@ abstract class AbstractXMLDoc
         }
 
         return Optional.empty();
+    }
+
+    private Optional<Node> getClassPropertyFieldElement(String property, String field) throws DocException
+    {
+        var domdoc = getDom();
+        if (domdoc == null) {
+            throw new DocumentNotFoundException();
+        }
+        if (property == null) {
+            throw new DocException("property is null. getValue expects a property.");
+        }
+        var root = domdoc.getRootElement();
+        var element = root.selectSingleNode(String
+            .format(fromRest ? XPATH_REST_CLASS_PROPERTY_FIELD : XPATH_XML_CLASS_PROPERTY_FIELD, property, field));
+        return Optional.ofNullable(element);
     }
 
     class DocumentNotFoundException extends DocException

--- a/src/main/java/org/xwiki/contrib/cli/document/CommandDoc.java
+++ b/src/main/java/org/xwiki/contrib/cli/document/CommandDoc.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import org.xwiki.contrib.cli.Command;
 import org.xwiki.contrib.cli.DocException;
 import org.xwiki.contrib.cli.document.element.AttachmentInfo;
+import org.xwiki.contrib.cli.document.element.ClassProperty;
 import org.xwiki.contrib.cli.document.element.ObjectInfo;
 
 /**
@@ -93,5 +94,17 @@ public class CommandDoc implements InputDoc
     public String getFriendlyName()
     {
         return "the command";
+    }
+
+    @Override
+    public Collection<ClassProperty> getClassInfo() throws DocException
+    {
+        throw new UnsupportedOperationException("Not Implemented");
+    }
+
+    @Override
+    public Optional<String> getClassPropertyField(String property, String field)
+    {
+        throw new UnsupportedOperationException("Not Implemented");
     }
 }

--- a/src/main/java/org/xwiki/contrib/cli/document/InputDoc.java
+++ b/src/main/java/org/xwiki/contrib/cli/document/InputDoc.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import org.xwiki.contrib.cli.DocException;
 import org.xwiki.contrib.cli.document.element.AttachmentInfo;
+import org.xwiki.contrib.cli.document.element.ClassProperty;
 import org.xwiki.contrib.cli.document.element.ObjectInfo;
 
 /**
@@ -77,4 +78,8 @@ interface InputDoc
      * @return a friendly string like "the XML file SomeDoc.xml"
      */
     String getFriendlyName();
+
+    Collection<ClassProperty> getClassInfo() throws DocException;
+
+    Optional<String> getClassPropertyField(String property, String field) throws DocException;
 }

--- a/src/main/java/org/xwiki/contrib/cli/document/InputXMLRestPage.java
+++ b/src/main/java/org/xwiki/contrib/cli/document/InputXMLRestPage.java
@@ -41,7 +41,7 @@ class InputXMLRestPage extends AbstractXMLDoc implements InputDoc
 
         this.page = page;
         this.wiki = wiki;
-        url = Utils.getDocRestURLFromCommand(cmd, wiki, page, true);
+        url = Utils.getDocRestURLFromCommand(cmd, wiki, page, true, true, true);
 
         var response = Utils.httpGet(cmd, url);
         var status = response.statusCode();

--- a/src/main/java/org/xwiki/contrib/cli/document/MultipleDoc.java
+++ b/src/main/java/org/xwiki/contrib/cli/document/MultipleDoc.java
@@ -32,6 +32,7 @@ import org.xwiki.contrib.cli.Command;
 import org.xwiki.contrib.cli.DocException;
 import org.xwiki.contrib.cli.Utils;
 import org.xwiki.contrib.cli.document.element.AttachmentInfo;
+import org.xwiki.contrib.cli.document.element.ClassProperty;
 import org.xwiki.contrib.cli.document.element.ObjectInfo;
 
 import static java.lang.System.err;
@@ -284,5 +285,44 @@ public class MultipleDoc implements InputDoc, OutputDoc
 
         err.println("Sorry, I didn't understand your answer. Please retry.");
         return pickInputFile(what);
+
+    }
+
+    @Override
+    public Collection<ClassProperty> getClassInfo() throws DocException
+    {
+        Collection<ClassProperty> classInfo = new ArrayList<>();
+        for (var inputDoc : inputDocs) {
+            var newClassInfo = inputDoc.getClassInfo();
+            if (classInfo.isEmpty()) {
+                classInfo = newClassInfo;
+            } else if (!newClassInfo.isEmpty() && !classInfo.equals(newClassInfo)) {
+                return pickInputFile("the class").getClassInfo();
+            }
+        }
+        return classInfo;
+    }
+
+    @Override
+    public Optional<String> getClassPropertyField(String property, String field) throws DocException
+    {
+        Optional<String> classPropertyField = Optional.empty();
+        for (var inputDoc : inputDocs) {
+            var newClassPropertyField = inputDoc.getClassPropertyField(property, field);
+            if (classPropertyField.isEmpty()) {
+                classPropertyField = newClassPropertyField;
+            } else if (newClassPropertyField.isPresent() && !classPropertyField.equals(newClassPropertyField)) {
+                return pickInputFile("the class property field").getClassPropertyField(property, field);
+            }
+        }
+        return classPropertyField;
+    }
+
+    @Override
+    public void setClassPropertyField(String property, String field, String value) throws DocException
+    {
+        for (var outputDoc : outputDocs) {
+            outputDoc.setClassPropertyField(property, field, value);
+        }
     }
 }

--- a/src/main/java/org/xwiki/contrib/cli/document/OutputDoc.java
+++ b/src/main/java/org/xwiki/contrib/cli/document/OutputDoc.java
@@ -71,4 +71,6 @@ public interface OutputDoc
      * @return a friendly string like "the XML file SomeDoc.xml"
      */
     String getFriendlyName();
+
+    void setClassPropertyField(String property, String field, String value) throws DocException;
 }

--- a/src/main/java/org/xwiki/contrib/cli/document/element/ClassProperty.java
+++ b/src/main/java/org/xwiki/contrib/cli/document/element/ClassProperty.java
@@ -1,0 +1,7 @@
+package org.xwiki.contrib.cli.document.element;
+
+import java.util.Map;
+
+public record ClassProperty(String name, Map<String, String> fields)
+{
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/projects/CLI/issues/CLI-16

# Changes

## Description

* Add class property edition support in document class

## Clarifications

For now it work on the wiki side as it's not implemented on the API cf https://jira.xwiki.org/browse/XWIKI-12597

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
    * No