### PR TITLE
[Misc] Fix all read commands returning nothing

### DIFF
--- a/src/main/java/org/xwiki/contrib/cli/document/MultipleDoc.java
+++ b/src/main/java/org/xwiki/contrib/cli/document/MultipleDoc.java
@@ -86,6 +86,10 @@ public class MultipleDoc implements InputOutputDoc
             outputDocs.add(new MvnRepoFileDoc(cmd, reference));
         }
 
+        if (StringUtils.isNotEmpty(cmd.url())) {
+            inputDocs.add(new InputXMLRestPage(cmd, wiki, reference));
+        }
+
         if (StringUtils.isNotEmpty(cmd.url()) && !cmd.noWriteWiki()) {
             outputDocs.add(new OutputXMLRestPage(cmd, wiki, reference));
         }


### PR DESCRIPTION
# Jira URL

None yet — happy to file a CLI issue if you'd like one for tracking (this fixes a regression rather than adding behavior).

# Changes

## Description

* Since fae86b3 (CLI-10), `MultipleDoc` no longer adds the wiki as an **input** source — only `OutputXMLRestPage` is registered when `--url` is set. Consequently all read commands (`--get-content`, `--get-title`, `--get-property`, `--list-objects`, `--list-properties`, `--list-attachments`) silently print nothing for any wiki page.
* This PR re-adds `InputXMLRestPage` to `inputDocs` when a URL is configured.

## Clarifications

* The pre-fae86b3 code guarded this with `!cmd.noReadWiki()`; that flag was removed in the same refactor, so the input is now added unconditionally whenever `--url` is set. If you'd prefer the flag restored instead, happy to adjust.

# Executed Tests

* Built with `mvn package -DskipTests=true` and as a GraalVM native image (`mvn -Pnative package`).
* Verified against a live XWiki 17.x instance: before the fix `--get-content`/`--get-title` print nothing; after the fix they return the correct content/title, and `--set-content` round-trips.

# Expected merging strategy

* Prefers squash: Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
