### PR TITLE
[Misc] Print data to stdout instead of System.console()

### DIFF
--- a/src/main/java/org/xwiki/contrib/cli/Command.java
+++ b/src/main/java/org/xwiki/contrib/cli/Command.java
@@ -559,7 +559,7 @@ public class Command
             void run(Command cmd) throws Exception
             {
                 var doc = new MultipleDoc(cmd);
-                System.console().printf(value(doc.getContent()) + "\n");
+                System.out.print(value(doc.getContent()) + "\n");
             }
         },
         SET_CONTENT {
@@ -576,7 +576,7 @@ public class Command
             void run(Command cmd) throws Exception
             {
                 var doc = new MultipleDoc(cmd);
-                System.console().printf(value(doc.getTitle()) + "\n");
+                System.out.print(value(doc.getTitle()) + "\n");
             }
         },
         SET_TITLE {
@@ -593,7 +593,7 @@ public class Command
             void run(Command cmd) throws Exception
             {
                 var doc = new MultipleDoc(cmd);
-                System.console().printf(value(doc.getValue(cmd.objectClass, cmd.objectNumber(), cmd.property).orElse("empty")) + "\n");
+                System.out.print(value(doc.getValue(cmd.objectClass, cmd.objectNumber(), cmd.property).orElse("empty")) + "\n");
             }
         },
         SET_PROPERTY_VALUE {
@@ -614,7 +614,7 @@ public class Command
             {
                 var doc = new MultipleDoc(cmd);
                 for (var object : doc.getObjects(cmd.objectClass, cmd.objectNumber(), cmd.property)) {
-                    System.console().printf(object.objectClass() + '/' + object.number() + "\n");
+                    System.out.print(object.objectClass() + '/' + object.number() + "\n");
                 }
             }
         },
@@ -633,7 +633,7 @@ public class Command
                         } else if (severalLines(val)) {
                             val = LINE + '\n' + val + LINE;
                         }
-                        System.console().printf(prop.name() + " = " + val + "\n");
+                        System.out.print(prop.name() + " = " + val + "\n");
                     }
                 }
             }
@@ -706,7 +706,7 @@ public class Command
             {
                 var doc = new MultipleDoc(cmd);
                 for (var attachment : doc.getAttachments()) {
-                    System.console().printf(attachment.name() + " (size: " + attachment.size() + ")\n");
+                    System.out.print(attachment.name() + " (size: " + attachment.size() + ")\n");
                 }
             }
         },
@@ -714,7 +714,7 @@ public class Command
             @Override
             void run(Command cmd)
             {
-                System.console().printf("xwiki-cli JAVA\n\n%s", HELP_TEXT);
+                System.out.print("xwiki-cli JAVA\n\n" + HELP_TEXT);
             }
         };
 

--- a/src/main/java/org/xwiki/contrib/cli/Main.java
+++ b/src/main/java/org/xwiki/contrib/cli/Main.java
@@ -62,7 +62,7 @@ final class Main
         File currentDirectory = new File("").getAbsoluteFile();
         File configFile = new File(currentDirectory, "xwikicli.config");
         if (configFile.exists()) {
-            System.console().printf("There is a xwikicli.config file in the current directory. Using it.\n");
+            System.err.print("There is a xwikicli.config file in the current directory. Using it.\n");
             readConfigFile(configFile.getAbsolutePath(), cmd);
         }
     }


### PR DESCRIPTION
# Jira URL

None yet — happy to file a CLI issue if you'd like one.

# Changes

## Description

* Data output currently goes through `System.console()`, which is `null` whenever stdout is piped or redirected. `xwiki-cli --help | less` crashes with a `NullPointerException`, and `--get-content > file.txt` writes nothing — making the CLI unusable in scripts.
* Printing content via `Console.printf(content + "\n")` also interprets the page content as a printf format string, so any page containing `%` crashes even in an interactive terminal.
* This PR prints data output via `System.out.print` (no format interpretation) and the `xwikicli.config` auto-load notice via `System.err`, so it doesn't pollute data output when stdout is consumed by a script.

## Clarifications

* The interactive REPL (`--repl`) keeps using `System.console()` — it genuinely requires an interactive terminal.

# Executed Tests

* Built with `mvn package -DskipTests=true` and as a GraalVM native image.
* Verified: `--help | head` and `--get-content > file` now work when piped; content containing `%` prints correctly.

# Expected merging strategy

* Prefers squash: Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
