### PR TITLE
[Misc] Include required resources in the native image

### DIFF
--- a/META-INF/native-image/resource-config.json
+++ b/META-INF/native-image/resource-config.json
@@ -1,6 +1,11 @@
 {
   "resources": {
-    "includes": []
+    "includes": [
+      {"pattern": ".*\\.xwiki$"},
+      {"pattern": "default_pom\\.xml$"},
+      {"pattern": ".*-version\\.properties$"},
+      {"pattern": ".*-dependees\\.properties$"}
+    ]
   },
   "bundles": [
     {


### PR DESCRIPTION
# Jira URL

None yet — happy to file a CLI issue if you'd like one.

# Changes

## Description

* `META-INF/native-image/resource-config.json` has an empty `includes` list, which breaks the native binary in two ways:
  * logback cannot read its `*-version.properties` and fails to initialize — every invocation starts with a `NullPointerException` stack trace from `VersionUtil.checkForVersionEquality`.
  * The CLI's own runtime resources (`default_pom.xml`, the `*.xwiki` scripts loaded via `getResourceAsStream`) are missing from the image, so the features using them fail at runtime.
* This PR includes those resources in the native image.

# Executed Tests

* Built the native image (`mvn -Pnative package`) and verified: the startup logback stack trace is gone, and `default_pom.xml`/`*.xwiki` resources resolve at runtime.

# Expected merging strategy

* Prefers squash: Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
